### PR TITLE
Update ERF25 info with the papers deadline

### DIFF
--- a/www/data/conf2025.json
+++ b/www/data/conf2025.json
@@ -43,7 +43,7 @@
     "name": "European Robotics Forum",
     "start": "2025-03-25",
     "end": "2025-03-27",
-    "deadline": "",
+    "deadline": "2024-09-30",
     "city": "Stuttgart",
     "country": "Germany",
     "link": "https://erf2025.eu/",


### PR DESCRIPTION
Hi Davide,
Thanks for maintaining this awesome list.

* ERF 2025 published a call for papers: https://eu-robotics.net/erf2025-call-for-papers/